### PR TITLE
upgrade: update PHP to 8.2, Laravel to 12.0, and streamline dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,10 +2,10 @@
   "name": "zihad/pilter",
   "description": "A filter package to help developers to attach filter queries to their query builder.",
   "type": "library",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "require": {
-    "php": "^8.0",
-    "laravel/framework": ">=9.0"
+    "php": "^8.2",
+    "laravel/framework": ">=12.0"
   },
   "license": "MIT",
   "autoload": {
@@ -34,15 +34,14 @@
   },
   "require-dev": {
     "pestphp/pest": "^3.0",
-    "nunomaduro/collision": "^8.1.1||^7.10.0",
-    "larastan/larastan": "^2.9||^3.0",
-    "orchestra/testbench": "^10.0.0||^9.0.0||^8.22.0",
+    "nunomaduro/collision": "^8.0",
+    "larastan/larastan": "^3.0",
+    "orchestra/testbench": "^10.0",
     "pestphp/pest-plugin-arch": "^3.0",
     "pestphp/pest-plugin-laravel": "^3.0",
-    "phpstan/extension-installer": "^1.3||^2.0",
-    "phpstan/phpstan-deprecation-rules": "^1.1||^2.0",
-    "phpstan/phpstan-phpunit": "^1.3||^2.0",
-    "spatie/laravel-ray": "^1.35"
+    "phpstan/extension-installer": "^1.3",
+    "phpstan/phpstan-deprecation-rules": "^2.0",
+    "phpstan/phpstan-phpunit": "^2.0"
   },
   "scripts": {
     "post-autoload-dump": "@composer run prepare",


### PR DESCRIPTION
This pull request updates the package requirements in `composer.json` to increase compatibility with newer versions of PHP and Laravel, as well as to update several development dependencies. The main goal is to ensure the package works with the latest frameworks and tooling.

Dependency and compatibility updates:

* Increased the minimum required PHP version to `^8.2` and Laravel framework version to `>=12.0` to ensure compatibility with the latest releases.
* Updated several development dependencies to require newer major versions, including `nunomaduro/collision`, `larastan/larastan`, `orchestra/testbench`, and `phpstan` packages, ensuring the development environment uses the latest tools.
* Removed the `spatie/laravel-ray` development dependency.

Versioning:

* Bumped the package version from `0.1.1` to `0.2.0` to reflect these breaking changes.